### PR TITLE
Fix draft watermark for safari

### DIFF
--- a/src/lib/components/post/Article.svelte
+++ b/src/lib/components/post/Article.svelte
@@ -6,7 +6,7 @@
   export let post: Post;
 </script>
 
-<div class={`grid grid-cols-4 items-start justify-center my-10 ${$$restProps.class} relative`}>
+<div class={`grid grid-cols-4 items-start justify-center my-10 relative ${$$restProps.class}`}>
   <article
     class="lg:text-lg w-full col-start-1 col-span-4 lg:col-span-3 max-w-[1000px] space-y-6 z-10"
   >
@@ -25,7 +25,7 @@
   </article>
   {#if post.draft}
     <p
-      class="z-0 fixed uppercase px-8 align-bottom text-error-100 text-9xl font-black leading-3 col-start-4 vertical-writing-lr"
+      class="z-0 right-10 lg:top-40 bottom-10 fixed uppercase px-8 align-bottom text-error-100 text-9xl font-black leading-3 col-start-4 vertical-writing-lr"
     >
       Draft
     </p>


### PR DESCRIPTION
The Draft watermark on Safari was positioned incorrectly. This adds more explicit positioning so the Safari renderer picks it up correctly too